### PR TITLE
Added a zoom/pan feature on the skilltree svg

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,13 +9,16 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "elm-community/linear-algebra": "3.1.2 <= v < 4.0.0",
         "elm-community/list-extra": "7.1.0 <= v < 8.0.0",
         "elm-community/maybe-extra": "4.0.0 <= v < 5.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",
-        "evancz/url-parser": "2.0.1 <= v < 3.0.0"
+        "elm-lang/virtual-dom": "2.0.4 <= v < 3.0.0",
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0",
+        "zaboco/elm-draggable": "3.1.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
- Based on [this example](https://github.com/zaboco/elm-draggable/blob/master/examples/PanAndZoomExample.elm). 
- Zoom with mousewheel and drag the skill tree to pan. 
- Zoom and pan are clamped.

PS: I am very new to elm, it might not be the cleanest code :smirk: